### PR TITLE
Alternative to query for entrezgene and HUGO symbol synonyms

### DIFF
--- a/Analysis_of_all_TCGA.Rmd
+++ b/Analysis_of_all_TCGA.Rmd
@@ -10,7 +10,7 @@ knitr::opts_chunk$set(echo = TRUE)
 ```
 
 
-```{r librarys}
+```{r libraries}
 library(FirebrowseR)
 library(BiocInstaller)
 library(biomaRt)
@@ -18,6 +18,8 @@ library(knitr)
 library(rlist)
 library(edgeR)
 library(statmod)
+library(org.Hs.eg.db)
+library(RSQLite) #
 ```
 
 ```{r settings}
@@ -42,7 +44,7 @@ opts_chunk$set(fig.width = 12,
 ## FIMO
 Preparation of FIMO list:
 
-```{bash, eval = FALSE}
+```{bash, eval = TRUE}
 mkdir utils
 
 cd $_
@@ -71,6 +73,7 @@ cut -f4 test.bed | sort | uniq -c | head
 
 cut -f4 test.bed | sort | uniq -c | sed 's/^\s*//' > fimo_transfac.txt
 mv fimo_transfac.txt ../data
+
 ```
 
 ```{r}
@@ -83,6 +86,8 @@ colnames(fimo_transfac)<- c("Number", "tf")
 ##JASPAR
 Preparation of JASPAR lists:
 
+Mind that these are too few TF, let's find other TF genome wide scans!
+
 ```{r jaspar}
 cmd <- 'wget https://noble.gs.washington.edu/custom-tracks/fimo.hg19.jaspar_core-0.1.bb;
 utils/bigBedToBed fimo.hg19.jaspar_core-0.1.bb jaspar_hg19.bed'
@@ -90,12 +95,14 @@ system(cmd)
 file.rename('jaspar_hg19.bed', file.path('data', 'jaspar_hg19.bed'))
 file.remove('fimo.hg19.jaspar_core-0.1.bb')
 
+## @todo fix this these are extremely few!!!
 jaspar_ids <- unique(read.table(file.path('data', 'jaspar_hg19.bed'),
                                 header = FALSE,
                                 stringsAsFactors = FALSE)$V4)
 
-length(jaspar_ids)
+print(length(jaspar_ids))
 ```
+
 Once we have our TF list we need to transfer the TRANSFAC codes to gene_ID of HGNC symbols, in order to do that we use the package biomaRt from bioconductor (first installation will take some time):
 
 ```{r martconfig}
@@ -103,13 +110,15 @@ Once we have our TF list we need to transfer the TRANSFAC codes to gene_ID of HG
 #listMarts()
 
 # You need the SNP mart
-mart <- useMart("ensembl")
+## mart <- useMart("ensembl")
+mart <- useMart("ENSEMBL_MART_ENSEMBL", host="grch37.ensembl.org",
+                path="/biomart/martservice", dataset="hsapiens_gene_ensembl")
 
 # Find homo sapiens
 #listDatasets(mart)
 
 # This will be the dataset we want to use
-dataset <- useDataset("hsapiens_gene_ensembl", mart=mart)
+## dataset <- useDataset("hsapiens_gene_ensembl", mart=mart)
 
 # Show available filters
 #listFilters(dataset)
@@ -118,21 +127,60 @@ dataset <- useDataset("hsapiens_gene_ensembl", mart=mart)
 #listAttributes(dataset)
 
 # To get the ensembl gene id belonging to the SNPs
-hgnc.factor.fimo.list<-getBM(attributes=c('hgnc_symbol','hgnc_id','hgnc_trans_name'), 
+hgnc.factor.fimo.list<-getBM(attributes=c('hgnc_symbol', 
+                                          'entrezgene'), 
       filters = 'external_gene_name', 
       values = fimo_transfac$tf, 
-      mart = dataset)
+      mart = mart)
+
+print(length(fimo_transfac$tf))
+print(nrow(hgnc.factor.fimo.list))
 
 hgnc.factor.fimo.list<-as.list(hgnc.factor.fimo.list)
 (hgnc.factor.fimo.list)
 
-hgnc.factor.jaspar.list<-getBM(attributes=c('hgnc_symbol','hgnc_id','hgnc_trans_name'), 
+hgnc.factor.jaspar.list<-getBM(attributes=c('hgnc_symbol','entrezgene'), 
       filters = 'external_gene_name', 
       values = jaspar_ids, 
-      mart = dataset)
+      mart = mart)
+
+print(length(jaspar_ids))
+print(nrow(hgnc.factor.jaspar.list))
 
 hgnc.factor.jaspar.list<-as.list(hgnc.factor.jaspar.list)
 (hgnc.factor.jaspar.list)
+```
+
+Alternative to deal with synonyms: first SQL query to disambiguate HUGO synonyms from valid gene symbols; then querying biomart to get the entrez ID that might be the one present at TCGA's data.
+
+```{r sql}
+
+con <- org.Hs.eg_dbconn()
+
+stmt <- 'SELECT * FROM alias, gene_info WHERE alias._id == gene_info._id;'
+# execute the query on the database
+aliases <- dbGetQuery(con, stmt)
+candidates <- aliases[aliases$alias_symbol %in% fimo_transfac$tf,]
+valid_symbols <- unique(candidates$symbol)
+
+old.hgnc.factor.fimo.list <- hgnc.factor.fimo.list
+
+# To get the ensembl gene id belonging to the SNPs
+hgnc.factor.fimo.list<-getBM(attributes=c('hgnc_symbol', 
+                                          'entrezgene'), 
+      filters = 'external_gene_name', 
+      values = valid_symbols, 
+      mart = mart)
+
+print(length(fimo_transfac$tf))
+print(length(valid_symbols))
+print(nrow(hgnc.factor.fimo.list))
+## print(nrow(old.hgnc.factor.fimo.list[1]))
+
+hgnc.factor.fimo.list<-as.list(hgnc.factor.fimo.list)
+(hgnc.factor.fimo.list)
+
+
 ```
 
 The preparation of this lists is on the List.rmd

--- a/diff_expression_proposal.Rmd
+++ b/diff_expression_proposal.Rmd
@@ -1,0 +1,202 @@
+---
+title: "COAD diff expression matched N and T proposal"
+output:
+  html_document:
+    keep_md: false
+    toc: true
+    toc_float: true
+    toc_depth: 4
+
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+# Setup
+
+```{r libraries}
+## library(FirebrowseR)
+## library(BiocInstaller)
+library(biomaRt)
+library(knitr)
+## library(rlist)
+library(edgeR)
+## library(statmod)
+library(org.Hs.eg.db)
+library(RSQLite) #
+```
+
+```{r settings}
+
+opts_chunk$set(fig.width = 12,
+               fig.height = 12,
+               cache = TRUE,
+               include = TRUE,
+               cache.lazy = FALSE,
+               warning = TRUE,
+               message = TRUE)
+
+```
+# TFBS data retrieval
+
+For transfac + fimo scans
+
+```{bash, eval = TRUE}
+mkdir -p utils 
+
+cd $_
+# retrieving transfac+fimo
+wget -q https://noble.gs.washington.edu/custom-tracks/fimo.hg19.transfac-0.1.bb
+
+# getting the exec for linux 64 bits
+
+rsync -aP rsync://hgdownload.soe.ucsc.edu/genome/admin/exe/linux.x86_64/bigBedToBed .
+
+# making it runnable
+
+chmod a+x bigBedToBed
+
+# converting to bed
+
+./bigBedToBed fimo.hg19.transfac-0.1.bb test.bed
+
+# checking how a bedfile looks like
+
+head test.bed
+
+cut -f4 test.bed | sort | uniq -c | sed 's/^\s*//' > fimo_transfac.txt
+mv fimo_transfac.txt ../data
+
+```
+
+```{r}
+fimo_transfac <- unique(read.table(file.path('data', 'fimo_transfac.txt'),
+                                header = FALSE,
+                                stringsAsFactors = FALSE))
+colnames(fimo_transfac)<- c("Number", "tf")
+
+```
+
+
+# Mapping
+
+## Symbols
+
+We would like to transform TRANSFAC names to HUGO symbols (we'll check differential expression of these using TCGA RSEM data)
+
+```{r mapping}
+
+con <- org.Hs.eg_dbconn()
+
+stmt <- 'SELECT * FROM alias, gene_info WHERE alias._id == gene_info._id;'
+# execute the query on the database
+aliases <- dbGetQuery(con, stmt)
+
+candidates <- aliases[aliases$alias_symbol %in% toupper(fimo_transfac$tf),]
+candidates2 <- aliases[aliases$symbol %in% toupper(fimo_transfac$tf),]
+
+valid_symbols <- unique(candidates$symbol, candidates2$symbol)
+```
+
+## Entrez IDs
+
+Gene symbols to Entrez gene ids (TCGA RSEMs also provide these identifiers)
+
+```{r biomart_entrez}
+
+mart <- useMart("ENSEMBL_MART_ENSEMBL", host="grch37.ensembl.org",
+                path="/biomart/martservice", dataset="hsapiens_gene_ensembl")
+
+
+entrez_tf <- getBM(attributes=c('hgnc_symbol', 
+                                'entrezgene'), 
+                   filters = 'external_gene_name', 
+                   values = valid_symbols,
+                   mart = mart)
+
+```
+
+# RSEM download for COAD
+
+COAD normalized RSEM expression values download from GDAC
+
+```{r coad_download}
+
+## using firebrowse instead?
+download.file('http://gdac.broadinstitute.org/runs/stddata__2016_01_28/data/COAD/20160128/gdac.broadinstitute.org_COAD.Merge_rnaseqv2__illuminahiseq_rnaseqv2__unc_edu__Level_3__RSEM_genes_normalized__data.Level_3.2016012800.0.0.tar.gz',  destfile = file.path('data', 'coad_rsem.tar.gz'))
+
+coad.fn <- grep('data.txt', untar(file.path('data', 'coad_rsem.tar.gz'), list = TRUE), value = TRUE)
+untar(file.path('data', 'coad_rsem.tar.gz'), files = coad.fn)
+
+header.coad <- read.table(file = coad.fn, sep = '\t', header = FALSE, nrow = 1,
+                     stringsAsFactors = FALSE)
+
+coad <- read.table(file = coad.fn, sep = '\t', header = TRUE, skip = 2)
+colnames(coad) <- header.coad[1,]
+
+rownames(coad) <- coad[,1]
+coad <- coad[,-1]
+rm(header.coad)
+
+```
+
+Getting a dictionary of TF with their TCGA id, Entrez id and standard gene symbol for which we know the TRANSFAC/FIMO motif.
+
+
+```{r}
+mapping <- data.frame(tcga = rownames(coad),
+                      entrez = sapply(strsplit(rownames(coad), '|', fixed = TRUE),
+                                      function(x) return(x[2])),
+                      symbol = sapply(strsplit(rownames(coad), '|', fixed = TRUE),
+                                      function(x) return(x[1])))
+
+tf <- merge(mapping, entrez_tf, by.x = 'entrez', by.y = 'entrezgene')
+
+head(tf)
+
+## so tf$tcga will contain the TCGA identifiers (rownames of COAD)
+dim(coad[tf$tcga,])
+
+```
+
+# Diff expression
+
+Getting sort of counts from RSEMs (this is not correct because we are just rounding RSEMs!) and generating a DGE object only for those samples that come from the same patient, because we will compare tumors against matched normals.
+
+```{r}
+
+coad <- round(coad) ## this is dirty, they are RSEMs and not counts!!!!!!!
+
+coldata <- data.frame(barcode = colnames(coad),
+                      sample = strtrim(sapply(strsplit(colnames(coad), '-', fixed = TRUE),
+                                              function(x) return(x[4])), 2),
+                      participant = sapply(strsplit(colnames(coad), '-', fixed = TRUE),
+                                              function(x) return(x[3]))
+                      )
+table(coldata$sample)
+## only normals and primary tumors
+coldata <- coldata[coldata$sample %in% c('01', '11'),]
+
+## only matched normal and tumor from the same participant
+selected <- coldata$participant[duplicated(coldata$participant)]
+coldata <- coldata[coldata$participant %in% selected,]
+coad <- coad[,coldata$barcode]
+
+coad_dge <- DGEList(coad, samples = coldata)
+
+```
+
+Norm factors
+
+```{r}
+coad_dge <- calcNormFactors(coad_dge)
+
+```
+Do tumors match tumors and normals match normals? Or do samples from the same participant cluster together? What does this mean (biologically)?
+
+```{r}
+plotMDS(coad_dge)
+```
+
+Differential expression analysis goes next.


### PR DESCRIPTION
Using a two layer query approach: first to disambiguate synonyms, then to retrieve their Entrez IDs by using biomaRt (TCGA ids are these ids if I'm not mistaken)

Still the number of TFs is too low (but a bit higher than before). Haven't checked the report nor knitted it, just played with the problem related to gene symbols.