### PR TITLE
GTF retrieval and call to bedtools

### DIFF
--- a/diff_expression_proposal.Rmd
+++ b/diff_expression_proposal.Rmd
@@ -200,3 +200,42 @@ plotMDS(coad_dge)
 ```
 
 Differential expression analysis goes next.
+
+```{r designmatrix}
+coldata$sample <- as.factor(as.character(coldata$sample))
+coldata$participant <- as.factor(as.character(coldata$participant))
+
+mmatrix <- model.matrix(~ 0 + sample + participant, data = coldata)
+
+rownames(mmatrix) <- coldata$barcode
+
+```
+
+```{r disp}
+
+coad_dge <- estimateDisp(coad_dge, mmatrix,robust = FALSE)
+```
+
+
+```{r}
+plotBCV(coad_dge)
+```
+
+
+
+```{r}
+coad_fit <-glmFit( coad_dge, mmatrix)
+coad_fit <- glmLRT(coad_fit,  contrast= 'specify the contrast') # update the contrast
+## topTags(coad_fit)
+
+```
+
+
+```{r}
+## summary(decideTests(coad_fit))
+```
+
+```{r}
+## plotMD(coad_fit)
+## abline(h=c(-1, 1), col="green")
+```

--- a/gtf_bedtools.sh
+++ b/gtf_bedtools.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+##
+## retrieves a human GTF from UCSC (hg19) and annotates a bedfile using bedtools
+##
+## 10th dec 2018
+## Izaskun Mallona
+
+wget http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/refGene.txt.gz
+
+## mind this is already compiled and only runs @ linux 64 bits!
+wget http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/genePredToGtf
+chmod a+x genePredToGtf 
+gzip -d refGene.txt.gz
+cut -f 2- refGene.txt > refGene.input
+./genePredToGtf file refGene.input hg19refGene.gtf
+wc -l hg19refGene.gtf
+
+## generating a random bedfile to annotate the intervals, just to exemplify the process
+
+cat << EOF > random.bed
+chr1,778752,779028
+chr1,869869,869987
+chr1,904737,904848
+chr1,912878,913154
+chr1,921093,921369
+chr1,923128,923404
+chr1,928866,929142
+chr1,939180,939456
+EOF
+
+sed -i 's/,/\t/g' random.bed
+
+bedtools intersect -a random.bed \
+         -b hg19refGene.gtf \
+         -wa -wb > random_annotated.bed
+
+wc -l random.bed
+wc -l random_annotated.bed ## beware! some are dupe, please read the GTF documentation
+## and the bedtools closest as well

--- a/preliminary work.Rmd
+++ b/preliminary work.Rmd
@@ -207,7 +207,7 @@ coad_dge <- DGEList(coad.barcode, samples = coad.data.2)
 
 Norm factors
 ```{r}
-coad_dge_norm <- calcNormFactors(coad_dge)
+coad_dge <- calcNormFactors(coad_dge)
 ```
 
 ```{r}
@@ -215,61 +215,46 @@ plotMDS(coad_dge_norm)
 ```
 
 Desing the matrix for the analysis:
-```{r}
-Normal<-factor(c("11"== coad_dge_norm$samples[5]))
-Tumor<-factor(c("01"== coad_dge_norm$samples[5]))
 
-matrix.model<-model.matrix(~Normal)
 
-rownames(matrix.model)<-colnames(coad_dge_norm$counts)
-head(matrix.model)
-dim(matrix.model)
+```{r designmatrix}
+coldata$sample <- as.factor(as.character(coldata$sample))
+coldata$participant <- as.factor(as.character(coldata$participant))
+mmatrix <- model.matrix(~ 0 + sample + participant, data = coldata)
+rownames(mmatrix) <- coldata$barcode
+dim(mmatrix)
 ```
-Do tumors match tumors and normals match normals? Yes they do, confirmed but only in the general mode.
 
-Or do samples from the same participant cluster together? I thought of the possibility but i dont know if that gives us additional information, we dont have other information about the participant we could use to, like if he/she is dead or alive or other kind of info, like weight, smoker or not (LUAD), etc...
+```{r disp}
+coad_dge <- estimateDisp(coad_dge, mmatrix,robust = FALSE)
+```
 
-What does this mean (biologically)? 
 
 ```{r}
-xy.coad.disp<-estimateDisp(coad_dge_norm,matrix.model,robust = FALSE)
-#Says it is redundant the Tumor column so we erase it
-xy.coad.disp$common.dispersion
+plotBCV(coad_dge)
 ```
 
 ```{r}
-plotBCV(xy.coad.disp)
+coad_fit <-glmFit( coad_dge, mmatrix)
+contrast<-c(1,-1,rep(0,25))
+coad_fit.1 <- glmLRT(coad_fit, contrast = contrast) # update the contrast
+## topTags(coad_fit)
+
 ```
 
 Differential expression:
 ```{r}
-coad.fit<-glmFit(xy.coad.disp, matrix.model)
-coad.lrt<-glmLRT(coad.fit)
-topTags(coad.lrt)
+summary(decideTests(coad_fit.1))
 ```
 
 ```{r}
-o.coad <- order(coad.lrt$table$PValue)
-coad.cpm<-cpm(xy.coad.disp)[o.coad[1:10],]
-head(colnames(coad.cpm))
-```
-
-```{r}
-summary(decideTests(coad.lrt))
-```
-
-```{r}
-plotMD(coad.lrt)
+plotMD(coad_fit.1)
 abline(h=c(-1, 1), col="green")
 ```
 
+
 ### Normal vs Tumor, general:
-coad.data <- data.frame(barcode = colnames(coad),
-                      sample = strtrim(sapply(strsplit(colnames(coad), '-', fixed = TRUE),
-                                              function(x) return(x[4])), 2),
-                      participant = sapply(strsplit(colnames(coad), '-', fixed = TRUE),
-                                              function(x) return(x[3]))
-                      )
+
 
 ```{r}
 #this way we split the rownames between the hgnc symbol and their number:

--- a/preliminary work.Rmd
+++ b/preliminary work.Rmd
@@ -18,14 +18,16 @@ knitr::opts_chunk$set(echo = TRUE)
 ```{r libraries}
 ## library(FirebrowseR)
 ## library(BiocInstaller)
-library(biomaRt)
-library(knitr)
-## library(rlist)
-library(edgeR)
-## library(statmod)
+##library(biomaRt)
+library("knitr")
+##library(rlist)
+## library(edgeR)
+##library(statmod)
 library(org.Hs.eg.db)
 library(RSQLite) #
-library(IRanges)
+##library(IRanges)
+BiocManager::install("edgeR")
+library(edgeR)
 ```
 
 ```{r settings}
@@ -304,3 +306,46 @@ summary(decideTests(coad.lrt.g))
 plotMD(coad.lrt.g)
 abline(h=c(-1, 1), col="green")
 ```
+
+# Finding the nearest genes:
+
+```{r biomart_GTF}
+mart <- useMart("ENSEMBL_MART_ENSEMBL", host="grch37.ensembl.org",
+                path="/biomart/martservice", dataset="hsapiens_gene_ensembl")
+
+
+GTF <- getBM(attributes=c('ensembl_gene_id',
+                          'external_gene_name',
+                          'chromosome_name',
+                          'external_gene_source',
+                          'gene_biotype',
+                          'transcript_source',
+                          'source',
+                          'source_name',
+                          'start_position',
+                          'end_position',
+                          'strand'
+                          ), 
+                   filters = 'hgnc_symbol', 
+                   values = entrez_tf$hgnc_symbol,
+                   mart = mart)
+
+# Show available filters
+#listFilters(dataset)
+
+# Now list all available attributes
+listAttributes(dataset)
+```
+
+```{r}
+GTF
+write.table(GTF,file = "GTF_file", sep = "\t")
+```
+
+
+```{bash}
+sed 's/[\t]*$//' GTF_file > GTF_file
+bedtools intersect -a GTF_file
+```
+
+


### PR DESCRIPTION
Hi, added a hg19 refGene retrieval from UCSC and a bedtools intersect call. Hope it helps #
321bae0.

Anyway I think this approach has a couple of issues: non overlapping coordinates won't be retrieved (this is an `bedtools intersect`, not a `bedtools closest`; and multiple GTF entries can be retrieved for each query `bed` file (i.e. overlapping annotations without caring about ties).

So in spite of sharing this (just to have a _working_ script with bedtools) I'd recommend using a R-based approach instead (i.e. annotating genomic ranges using `ChIPpeakAnno` or similar)